### PR TITLE
configure: if setmandir -> $setmandir

### DIFF
--- a/configure
+++ b/configure
@@ -165,7 +165,7 @@ do
   esac
 done
 
-if [ setmandir -eq 0 ] ; then
+if [ $setmandir -eq 0 ] ; then
   mandir="$prefix/man"
 fi
 


### PR DESCRIPTION
`[ setmandir -eq 0 ]` will never be true and instead worst error out because `-eq` suggests both sides should be evaluated as an integer expression.