### PR TITLE
regex.h: remove __{BEGIN,END}_DECLS

### DIFF
--- a/regex.h
+++ b/regex.h
@@ -96,11 +96,9 @@ typedef struct {
 #define	REG_LARGE	01000	/* force large representation */
 #define	REG_BACKR	02000	/* force use of backref code */
 
-__BEGIN_DECLS
 int	regcomp(regex_t *, const char *, int);
 size_t	regerror(int, const regex_t *, char *, size_t);
 int	regexec(const regex_t *, const char *, size_t, regmatch_t [], int);
 void	regfree(regex_t *);
-__END_DECLS
 
 #endif /* !_REGEX_H_ */


### PR DESCRIPTION
On Alpine Linux (musl-based), <sys/types.h> does not define `__BEGIN_DECLS` and `__END_DECLS` that is found on OpenBSD and Linux/glibc. `__BEGIN_DECLS` and `__END_DECLS` thus cause the build to error on Alpine Linux at the least.

The purpose of these macros appears to be adding extern "C" around the declarations for when they're included in C++ code. oed contains no C++ code, so they serve no functional purpose to begin with.

regex.h can be expected not to change much (if at all) in upstream OpenBSD, so this removal likely won't cause any issues going forward.