### PR TITLE
Fix compilation with musl libc

### DIFF
--- a/regex.h
+++ b/regex.h
@@ -94,11 +94,9 @@ typedef struct {
 #define	REG_LARGE	01000	/* force large representation */
 #define	REG_BACKR	02000	/* force use of backref code */
 
-__BEGIN_DECLS
 int	regcomp(regex_t *, const char *, int);
 size_t	regerror(int, const regex_t *, char *, size_t);
 int	regexec(const regex_t *, const char *, size_t, regmatch_t [], int);
 void	regfree(regex_t *);
-__END_DECLS
 
 #endif /* !_REGEX_H_ */


### PR DESCRIPTION
musl does not support `__BEGIN_DECLS` / `__END_DECLS` and claims
that these macros are not supposed to be used by any program.

See https://wiki.musl-libc.org/faq.html#Q:_When_compiling_something_against_musl,_I_get_error_messages_about_%3Ccode%3Esys/cdefs.h%3C/code%3E

In this case, `regex.h` is only included from C code. Hence there
is no need to keep the macros. They can be safely removed and do not
need to be replace with a `extern "C"` declaration.